### PR TITLE
Webix version update (2.5.14)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>webix</artifactId>
-    <version>2.3.9-SNAPSHOT</version>
+    <version>2.5.14-SNAPSHOT</version>
     <name>Webix</name>
     <description>WebJar for Webix</description>
     <url>http://webjars.org</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>2.3.8</upstream.version>
+        <upstream.version>2.5.14</upstream.version>
         <upstream.url>http://github.com/webix-hub/tracker/archive/${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>


### PR DESCRIPTION
Can you release a webjar for Webix version 2.5.14 please? I'll then update to Webix 3.0, but I think it's good to provide the last stable v2. Thanks!
